### PR TITLE
マイページの過去の取引の商品がクリックされるとエラーになる問題の解消

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -4,7 +4,7 @@ class OrdersController < ApplicationController
     order = Order.find_by(product_id: @product.id)
     # ユーザーは自身が購入した商品の取引画面にしか入れないようにする
     if user_signed_in?
-      unless @product.exhibit_trading? && current_user.id == order.buyer_id
+      unless ( @product.exhibit_trading? || @product.exhibited? ) && current_user.id == order.buyer_id
         # 直前の画面に戻る
         return_back and return
       end

--- a/app/views/orders/show.html.haml
+++ b/app/views/orders/show.html.haml
@@ -4,11 +4,19 @@
   %section.mercari-transaction__container
     %section.mercari-transaction__container__messages
       .mercari-transaction__container__messages__1
-        %i.far.fa-clock
-        %p 発送をお待ちください
+        - if @product.exhibit_trading?
+          %i.far.fa-clock
+          %p 発送をお待ちください
+        - if @product.exhibited?
+          %i.fas.fa-check
+          %p 取引が完了しました
       .mercari-transaction__container__messages__2
-        %p 出品者からの発送通知をお待ちください
-    %h2 購入が完了しました
+        - if @product.exhibit_trading?
+          %p 出品者からの発送通知をお待ちください
+        - if @product.exhibited?
+          %p このたびはメルカリのご利用ありがとうございました。
+    - if @product.exhibit_trading?
+      %h2 購入が完了しました
     %section.mercari-transaction__container__transaction-item
       .mercari-transaction__container__transaction-item__inner
         .mercari-transaction__container__transaction-item__inner__item


### PR DESCRIPTION
 # What
過去の取引の商品がクリックされるとエラーになることを解消する。また、取引中の商品ページと一部表記を変化させること。
# Why
エラーの解消のため。